### PR TITLE
Adds new QC vaccination situation CSV in FR and EN.

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,8 @@ When both French and English data files are available, French files should gener
 * [COVID-19 vaccination data](https://www.quebec.ca/en/health/health-issues/a-z/2019-coronavirus/situation-coronavirus-in-quebec/covid-19-vaccination-data/)
     * [Webpage EN](https://www.quebec.ca/en/health/health-issues/a-z/2019-coronavirus/situation-coronavirus-in-quebec/covid-19-vaccination-data/): [qc/qc-vaccination-webpage-en/qc-vaccination-webpage-en.html](https://drive.google.com/drive/folders/1h-b5MPDH3BpwP2mFdZfagrWx1x704AMR)
     * [Webpage FR](https://www.quebec.ca/sante/problemes-de-sante/a-z/coronavirus-2019/situation-coronavirus-quebec/donnees-sur-la-vaccination-covid-19/): [qc/qc-vaccination-webpage-fr/qc-vaccination-webpage-fr.html](https://drive.google.com/drive/folders/1DXrSwretQqG8RU-Dzhd-eODxCjlEnIIk)
+    * Vaccination situation (FR): [qc/vaccination-situation/situation-vaccination.csv](TBD)
+    * Vaccination situation (EN): [qc/vaccination-situation-en/situation-vaccination-en.csv](TBD)
     * Vaccine doses administered by RSS (FR): [qc/vaccine-doses-admin-by-rss/doses-vaccins.csv](https://drive.google.com/drive/folders/1-ileQelY2aoJFcCSJSu3JG6bZrGWFFbS)
     * Vaccine doses administered by RSS (EN): [qc/vaccine-doses-admin-by-rss-en/doses-vaccins-en.csv](https://drive.google.com/drive/folders/1MWPkSGMfOMGqJNNv7LEJzWA1AAB3h3yI) (note: the first file in this dataset is only available as a screenshot; archived as of 2021-01-14, no longer part of the nightly update)
     * Vaccine doses received (FR): [qc/vaccine-doses-received-7-days/doses-vaccins-7jours.csv](https://drive.google.com/drive/folders/1z-N_RuVWOqKO3pyCM8skkdhf_tkapPPE

--- a/archiver.py
+++ b/archiver.py
@@ -685,6 +685,16 @@ archivist.dl_file('https://cdn-contenu.quebec.ca/cdn-contenu/securitepublique/do
                   'qc/correctional-cases-detainees-en/',
                   'donnees_covid_detention_personnes_incarcerees_EN')
 
+# QC - Vaccination situation (FR)
+archivist.dl_file('https://cdn-contenu.quebec.ca/cdn-contenu/sante/documents/Problemes_de_sante/covid-19/csv/situation-vaccination.csv',
+                  'qc/vaccination-situation/',
+                  'situation-vaccination')
+
+# QC - Vaccination situation (EN)
+archivist.dl_file('https://cdn-contenu.quebec.ca/cdn-contenu/sante/documents/Problemes_de_sante/covid-19/csv/situation-vaccination-en.csv',
+                  'qc/vaccination-situation-en/',
+                  'situation-vaccination-en')
+
 # QC - Vaccine doses administered by RSS (FR)
 archivist.dl_file('https://cdn-contenu.quebec.ca/cdn-contenu/sante/documents/Problemes_de_sante/covid-19/csv/doses-vaccins.csv',
                   'qc/vaccine-doses-admin-by-rss/',


### PR DESCRIPTION
Starting today (AFAIK) there is a new vaccination situation CSV in both French and English.

It does not contain any new information (that is not already available in the other CSVs) but it does contain the date for both totals (doses administered and doses received).